### PR TITLE
configure static storage to add a hash when naming static files

### DIFF
--- a/investment_club/settings.py
+++ b/investment_club/settings.py
@@ -143,6 +143,15 @@ STATICFILES_DIRS = [
 
 STATIC_URL = "/static/"
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 


### PR DESCRIPTION
# What does this PR do?
- Configures settings to add a hash to static files when they are named, this way each time static files are collected, if they have been modified they get new names. This bypasses the problem of caching referencing old files.